### PR TITLE
docs(siliconCloud): update descriptions to markdown for model and token

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,12 +68,12 @@
           "var-conv-next.siliconCloud.model": {
             "type": "string",
             "default": "",
-            "description": "启用 SiliconCloud 需提供 Model"
+            "markdownDescription": "启用 SiliconCloud 需提供 Model, 详见: [平台模型列表](https://docs.siliconflow.cn/docs/model-names)"
           },
           "var-conv-next.siliconCloud.token": {
             "type": "string",
             "default": "",
-            "description": "启用 SiliconCloud 需提供 Token"
+            "markdownDescription": "启用 SiliconCloud 需提供 Token, 详见: [API密钥](https://cloud.siliconflow.cn/account/ak)"
           }
         }
       }

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -3,8 +3,7 @@ function styles(variable: string, style: string) {
     camel: {
       name: 'camel',
       prompts: [
-`
-Target：Implement variable naming style conversion.\n`,
+`Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
 `Change style：${style} case\n`,
 `Style introduce：The first word is lowercase, and the first letter of the next word is uppercase, without delimiters.\n`,
@@ -15,8 +14,7 @@ Target：Implement variable naming style conversion.\n`,
     pascal: {
       name: 'pascal',
       prompts: [
-`
-Target：Implement variable naming style conversion.\n`,
+`Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
 `Change style：${style} case\n`,
 `Style introduce：The first letter of each word is capitalized without delimiters.\n`,
@@ -27,8 +25,7 @@ Target：Implement variable naming style conversion.\n`,
     kebab: {
       name: 'kebab',
       prompts: [
-`
-Target：Implement variable naming style conversion.\n`,
+`Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
 `Change style：${style} case\n`,
 `Style introduce：All letters are lowercase, separated by a dash of "-".\n`,
@@ -39,8 +36,7 @@ Target：Implement variable naming style conversion.\n`,
     snake: {
       name: 'snake',
       prompts: [
-`
-Target：Implement variable naming style conversion.\n`,
+`Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
 `Change style：${style} case\n`,
 `Style introduce：All letters are lowercase and words are separated by the underscore "_".\n`,
@@ -51,8 +47,7 @@ Target：Implement variable naming style conversion.\n`,
     constant: {
       name: 'constant',
       prompts: [
-`
-Target：Implement variable naming style conversion.\n`,
+`Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
 `Change style：${style} case\n`,
 `Style introduce：All letters are capitalized and words are separated by the underscore "_".\n`,


### PR DESCRIPTION
Update the `description` fields for `var-conv-next.siliconCloud.model` and
`var-conv-next.siliconCloud.token` to `markdownDescription` with links to
external documentation. This enhances the user's access to detailed information
about the SiliconCloud model and API key setup.