### PR TITLE
refactor(prompt): dynamic style handling in prompt function

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -2,12 +2,13 @@
   "version": "0.2.0",
   "configurations": [
     {
-      "name": "Extension",
+      "name": "Run Extension",
       "type": "extensionHost",
       "request": "launch",
       "runtimeExecutable": "${execPath}",
       "args": [
-        "--extensionDevelopmentPath=${workspaceFolder}"
+        "--extensionDevelopmentPath=${workspaceFolder}",
+        "--disable-extensions"
       ],
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"

--- a/src/prompt.ts
+++ b/src/prompt.ts
@@ -1,11 +1,11 @@
-function styles(variable: string, style: string) {
+function styles(variable: string) {
   return {
     camel: {
       name: 'camel',
       prompts: [
 `Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
-`Change style：${style} case\n`,
+`Change style：camel case\n`,
 `Style introduce：The first word is lowercase, and the first letter of the next word is uppercase, without delimiters.\n`,
 `Tip 1: Output only converted variable names.\n`,
 `Tip 2: Output directly if it matches the style.\n`,
@@ -16,7 +16,7 @@ function styles(variable: string, style: string) {
       prompts: [
 `Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
-`Change style：${style} case\n`,
+`Change style：pascal case\n`,
 `Style introduce：The first letter of each word is capitalized without delimiters.\n`,
 `Tip 1: Output only converted variable names.\n`,
 `Tip 2: Output directly if it matches the style.\n`,
@@ -27,7 +27,7 @@ function styles(variable: string, style: string) {
       prompts: [
 `Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
-`Change style：${style} case\n`,
+`Change style：kebab case\n`,
 `Style introduce：All letters are lowercase, separated by a dash of "-".\n`,
 `Tip 1: Output only converted variable names.\n`,
 `Tip 2: Output directly if it matches the style.\n`,
@@ -38,7 +38,7 @@ function styles(variable: string, style: string) {
       prompts: [
 `Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
-`Change style：${style} case\n`,
+`Change style：snake case\n`,
 `Style introduce：All letters are lowercase and words are separated by the underscore "_".\n`,
 `Tip 1: Output only converted variable names.\n`,
 `Tip 2: Output directly if it matches the style.\n`,
@@ -49,7 +49,7 @@ function styles(variable: string, style: string) {
       prompts: [
 `Target：Implement variable naming style conversion.\n`,
 `Input variable：${variable}\n`,
-`Change style：${style} case\n`,
+`Change style：constant case\n`,
 `Style introduce：All letters are capitalized and words are separated by the underscore "_".\n`,
 `Tip 1: Output only converted variable names.\n`,
 `Tip 2: Output directly if it matches the style.\n`,
@@ -59,7 +59,6 @@ function styles(variable: string, style: string) {
 }
 
 export default function prompt(variable: string, style: string) {
-  const _style = styles(variable, style)
-  const result = Reflect.get(_style, style).prompts
+  const result = Reflect.get(styles(variable), style).prompts
   return result
 }


### PR DESCRIPTION
Remove the static style parameter from the styles function to simplify dynamic
handling of variable naming styles in the prompt generation. Adjust the prompt
function to use the updated styles method, eliminating the need for the redundant
_style variable and directly accessing the appropriate style prompts through
Reflect.get. This change streamlines the code structure and enhances maintainability
by centralizing the style variation logic within the styles function.