### PR TITLE
feat(vscode): add playground for extension testing

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -8,7 +8,8 @@
       "runtimeExecutable": "${execPath}",
       "args": [
         "--extensionDevelopmentPath=${workspaceFolder}",
-        "--disable-extensions"
+        "--disable-extensions",
+        "${workspaceFolder}/playground.ts"
       ],
       "outFiles": [
         "${workspaceFolder}/dist/**/*.js"

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -5,6 +5,7 @@ export default antfu(
   {
     ignores: [
       // eslint ignore globs here
+      'playground.ts',
     ],
   },
   {

--- a/playground.ts
+++ b/playground.ts
@@ -1,0 +1,13 @@
+/**
+ * 测试插件运行情况
+ */
+
+const CamelCase = 'helloWorld'
+
+const PascalCase = 'HelloWorld'
+
+const KebabCase = 'hello-world'
+
+const SnakeCase = 'HELLO_WORLD'
+
+const ConstantCase = 'Hello_World'


### PR DESCRIPTION
A playground environment has been set up to facilitate extension testing within the VSCode development environment. This includes modification to launch configuration for execution of playground.ts and addition of playground.ts with test cases demonstrating various case conversions.